### PR TITLE
Add nancy to benchmarks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem "nyny",     git: "https://github.com/alisnic/nyny",            branch: "mast
 gem "ramaze"
 gem "scorched", git: "https://github.com/Wardrop/Scorched",        branch: "master"
 gem "sinatra"
+gem "nancy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,9 @@ GEM
       rack
     innate (2013.02.21)
       rack (~> 1.5.2)
+    nancy (0.3.0)
+      rack
+      tilt
     puma (2.6.0)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
@@ -63,6 +66,7 @@ DEPENDENCIES
   brooklyn!
   cuba
   hobbit!
+  nancy
   nyny!
   puma (~> 2.6.0)
   ramaze

--- a/nancy.ru
+++ b/nancy.ru
@@ -1,0 +1,9 @@
+require "nancy"
+
+class HelloWorld < Nancy::Base
+  get "/" do
+    "Hello World!"
+  end
+end
+
+run HelloWorld


### PR DESCRIPTION
numbers are similar to brooklyn (on my machine), still being slower than cuba:

```
rack: 7499.86 req/s
cuba: 6293.87 req/s
nancy: 5163.81 req/s
brooklyn: 5152.42 req/s
```
