### PR TITLE
Add a rack app using Rack::Response instead of [status, headers, body]

### DIFF
--- a/rack-response.ru
+++ b/rack-response.ru
@@ -1,0 +1,7 @@
+class HelloWorld
+  def call(env)
+    Rack::Response.new('Hello World!', 200, { 'Content-Type' => 'text/html' }).finish
+  end
+end
+
+run HelloWorld.new


### PR DESCRIPTION
It's funny to see how the performance drops using `Rack::Response`.

For reference, in my machine:

```
rack                      6682.88 req/s
rack using Rack::Response 5268.26 req/s
```
