### PR TITLE
Try to make benchmarks fair

### DIFF
--- a/apps/cuba.ru
+++ b/apps/cuba.ru
@@ -1,7 +1,7 @@
 require "cuba"
 
 HelloWorld = Cuba.new do
-  on default do
+  on get, /\z/ do
     res.write "Hello World!"
   end
 end

--- a/apps/lotus-router.ru
+++ b/apps/lotus-router.ru
@@ -1,8 +1,7 @@
 require "lotus/router"
 
 APP = Lotus::Router.new do
-  get "/", to: ->(env) { [200, {}, ["Hello World!"]] }
-  get "/:name", to: ->(env) { [200, {}, ["Hello name!"]] }
+  get "/", to: ->(env) { [200, {'Content-Type'=>'text/html'}, ["Hello World!"]] }
 end
 
 run APP

--- a/apps/mustermann.ru
+++ b/apps/mustermann.ru
@@ -2,12 +2,11 @@ require "mustermann/router/rack"
 
 APP = Mustermann::Router::Rack.new do
   on '/' do |env|
-    [200, {'Content-Type' => 'text/plain'}, ['Hello World!']]
-  end
-
-  on '/:name' do |env|
-    name = env['mustermann.params']['name']
-    [200, {'Content-Type' => 'text/plain'}, ["Hello #{name}!"]]
+    if env['REQUEST_METHOD'] == 'GET'
+      [200, {'Content-Type' => 'text/plain'}, ['Hello World!']]
+    else
+      [404, {'Content-Type' => 'text/plain'}, []]
+    end
   end
 end
 

--- a/apps/rack-response.ru
+++ b/apps/rack-response.ru
@@ -1,6 +1,10 @@
 class HelloWorld
   def call(env)
-    Rack::Response.new('Hello World!', 200, { 'Content-Type' => 'text/html' }).finish
+    if env['REQUEST_METHOD'] == 'GET' && env['PATH_INFO'] == '/'
+      Rack::Response.new('Hello World!', 200, { 'Content-Type' => 'text/html' }).finish
+    else
+      Rack::Response.new('', 404, { 'Content-Type' => 'text/html' }).finish
+    end
   end
 end
 

--- a/apps/rack.ru
+++ b/apps/rack.ru
@@ -1,10 +1,18 @@
 class HelloWorld
   def call(env)
-    [
-      200,
-      {"Content-Type" => "text/html"},
-      ["Hello World!"]
-    ]
+    if env['REQUEST_METHOD'] == 'GET' && env['PATH_INFO'] == '/'
+      [
+        200,
+        {"Content-Type" => "text/html"},
+        ["Hello World!"]
+      ]
+    else
+      [
+        404,
+        {"Content-Type" => "text/html"},
+        [""]
+      ]
+    end
   end
 end
 


### PR DESCRIPTION
Currently, the benchmarks are not fair because some apps return a 200 for
all requests, and other apps return 200 only for GET /. The apps that return
200 only for GET / obviously have to do more work, so they shouldn't get
penalized for it.

This fixes the following issues:
- The cuba, rack, and rack-response apps all return 200 for all requests, not
  just GET /.
- The mustermann app returns 200 for any request method with /, not just GET /.
- The lotus-router app doesn't return a rack response that is valid according
  to Rack::Lint.

This also removes unused routes from the lotus-router and mustermann apps.

Note that I didn't do an exhaustive check of all apps, there may be others
that also have similar issues (gin and ramaze don't check the request method
from the looks of it).

This pull request doesn't include this, but I recommend adding some tests
that all apps must pass before benchmarking:
- GET / returns 200
- GET /foo returns 404
- POST / returns 404 or 405
- Rack::Lint passes for all 3 of the above requests
- Possibly that all apps return a correct Content-Length header for the body

The alternate approach here is that all apps are allowed to return 200 for all
requests (or 200 for both GET / and POST / and 404 for others), in which case
I'll submit a different pull request.
